### PR TITLE
Fix JTAG Enumration page

### DIFF
--- a/docs/debug-interfaces/jtag.md
+++ b/docs/debug-interfaces/jtag.md
@@ -30,35 +30,9 @@ $ avarice --program --file test.elf --part atmega128 --jtag /dev/ttyUSB0 :4444
 $ avrdude -p m128 -c jtagmkI –P /dev/ttyUSB0 -U flash:r:”/home/avr/flash.bin":r
 ```
 
-### JTAGEnum
+### Enumeration methods
 
-JTAGenum is an open source Arduino JTAGenum.ino or RaspbberyPi JTAGenum.sh (experimental) scanner. This code was built with three primary goals:
-
-* Given a large set of pins on a device determine which are JTAG lines
-* Enumerate the Instruction Register to find undocumented functionality
-
-⚠️ JTAG and device must share the same ground.
-
-Software Connection Set up:
-
-* Download the INO sketch from the github
-* Open the Arduino IDE and Load the downloaded JTAGEnum sketch
-* Choose the correct Serial Port and Board
-* Compile and Upload the sketch
-* Open the Serial Monitor
-* Set the correct baud rate
-* Enter the command to scan ("s")
-
-Arduino PIN Layout
-
-* Digital PIN 2(Black)
-* Digital PIN 3(White)
-* Digital PIN 4(Grey)
-* Digital PIN 5(Maroon)
-* Digital PIN 6(Blue)
-* GND - GREEN
-
-![](https://3.bp.blogspot.com/-OmjCNFWbnf0/WKx4NEjfb9I/AAAAAAAADy8/-qz5Of4iDbcT5mtonl6st1hVGrmsGUs4gCLcB/s640/FOUND.png)
+For enumeration methods see [Enumeration/JTAG](/enumeration/jtag/)
 
 ### References
 

--- a/docs/enumeration/jtag.md
+++ b/docs/enumeration/jtag.md
@@ -6,7 +6,7 @@ There are several tools and ways to enumerate JTAG pins. Here are few:
 
 * Probing pin voltage, resistence to VCC and GND (TODO)
 * Searching with Joe Grand's JTAGulator (TODO)
-* Using an Arduino Pro Micro (TODO)
+* [Using an Arduino Pro Micro](#jtagenum-with-arduino-or-raspberry-pi)
 * [Using an Raspberry Pi Pico](#searching-jtag-pins-with-raspberry-pi-pico)
 
 ## Searching JTAG pins with Raspberry PI Pico
@@ -22,13 +22,13 @@ It has two approaches:
 * Try reading `IDCODE` - Only requires TMS, TCK and TDO so it's faster. Unfortunately not all devices support `IDCODE` command (although most of them do). This doesn't find the TDI pin.
 * Shifting bits in `BYPASS` mode. This can find all pins, but it is slower (since not only you have one more pin to iterate over, but also need to shift "enough" bits through the JTAG Chain).
 
-![RP2040 Board with 33 Ohm series resistor](../assets/rp2040-jtagscan-resistors.png)
-
 ### Hardware suggestions
 
 Any raspberry pi pico board should work fine for scanning JTAG ports. Make sure you check the VCC of the target to see if it is 3.3V. Being other voltage level will require a level-shifter to avoid damage.
 
 It is also recommended to use series 33 Ohm resistors in series with every tested pin to avoid short circuiting if some pin you're testing is an output.
+
+![RP2040 Board with 33 Ohm series resistor](../assets/rp2040-jtagscan-resistors.png)
 
 ### Programming the PiPico
 
@@ -77,3 +77,39 @@ Hit `a` for scan the JTAG pins. This will do first a `IDCODE` scan and then a `B
 +----------- SUCCESS -----------+
 ```
 
+
+## JTAGEnum with Arduino or Raspberry Pi
+
+JTAGenum is an open source Arduino JTAGenum.ino or RaspbberyPi JTAGenum.sh (experimental) scanner. This code was built with three primary goals:
+
+* Given a large set of pins on a device determine which are JTAG lines
+* Enumerate the Instruction Register to find undocumented functionality
+
+⚠️ JTAG and device must share the same ground.
+
+Software Connection Set up:
+
+* Download the INO sketch from the github
+* Open the Arduino IDE and Load the downloaded JTAGEnum sketch
+* Choose the correct Serial Port and Board
+* Compile and Upload the sketch
+* Open the Serial Monitor
+* Set the correct baud rate
+* Enter the command to scan ("s")
+
+Arduino PIN Layout
+
+* Digital PIN 2(Black)
+* Digital PIN 3(White)
+* Digital PIN 4(Grey)
+* Digital PIN 5(Maroon)
+* Digital PIN 6(Blue)
+* GND - GREEN
+
+![](https://3.bp.blogspot.com/-OmjCNFWbnf0/WKx4NEjfb9I/AAAAAAAADy8/-qz5Of4iDbcT5mtonl6st1hVGrmsGUs4gCLcB/s640/FOUND.png)
+
+### References
+
+* [JTAGulator vs. JTAGenum, Tools for Identifying JTAG Pins in IoT Devices by Dylan Ayrey](https://www.praetorian.com/blog/jtagulator-vs-jtagenum-tools-for-identifying-jtag-pins-in-iot-devices?edition=2019)
+* [JTAG PIN Identification - February 21, 2017](https://just2secure.blogspot.com/2017/02/jtag-pin-identification.html)
+* [Hardware Debugging for Reverse Engineers Part 2: JTAG, SSDs and Firmware Extraction - Posted Apr 2, 2020 by wrongbaud](https://wrongbaud.github.io/posts/jtag-hdd/)


### PR DESCRIPTION
There was some JTAG Enumeration text in JTAG about page, so I moved the content to enumeration/jtag and made a reference to the page.